### PR TITLE
doc: fix missing docstring (D104) from codacy

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Daniele Tentoni <daniele.tentoni.1996@gmail.com
 #
 # SPDX-License-Identifier: MIT
+
+"""Coding Challenge Code Checker"""


### PR DESCRIPTION
This commit fix an issue raised from a [Codacy PR report](https://app.codacy.com/gh/Daniele-Tentoni/cc-codechecker/pullRequest?prid=8921359).